### PR TITLE
Show message when not matching events were found

### DIFF
--- a/templates/event_list.html
+++ b/templates/event_list.html
@@ -49,13 +49,17 @@
                     {% get_pages %}
             </tbody>
         </table>
+        {% if not object_list %}
+            <p>No events were found.</p>
+        {% endif %}
+            
     </div> 
+    {% if object_list %}
+        <div class="row">
+            <div class="col">
+                {% include "pagination.html" %}
+            </div>
 
-    <div class="row">
-        <div class="col">
-            {% include "pagination.html" %}
-        </div>
-
-    </div>  
-
+        </div>  
+    {% endif %}
 </div>


### PR DESCRIPTION
We show a message when the result table is empty