### PR TITLE
Create StateManager class

### DIFF
--- a/search_events_app/services/state_manager.py
+++ b/search_events_app/services/state_manager.py
@@ -1,0 +1,10 @@
+class StateManager:
+    events = None
+
+    @classmethod
+    def set_events(cls, events):
+        cls.events = events
+
+    @classmethod
+    def get_last_searched_events(cls):
+        return cls.events

--- a/search_events_app/tests/services/test_state_manager.py
+++ b/search_events_app/tests/services/test_state_manager.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+
+from search_events_app.models.event import Event
+from search_events_app.services.state_manager import StateManager
+
+
+class TestStateManager(TestCase):
+    def setUp(self):
+        self.events = [
+            Event('Event1', 'wwww.google.com', 'Argentina'),
+            Event('Event2', 'wwww.google.com', 'United States'),
+            Event('Event3', 'wwww.google.com', 'Ireland'),
+            Event('Event4', 'wwww.google.com', 'Argentina'),
+            Event('Event5', 'wwww.google.com', 'Chile'),
+        ]
+
+    def test_set_events(self):
+        StateManager.set_events(self.events)
+        result = StateManager.events
+        self.assertEqual(result, self.events)
+
+    def test_get_last_searched_events(self):
+        StateManager.events = self.events
+        result = StateManager.get_last_searched_events()
+        self.assertEqual(result, self.events)


### PR DESCRIPTION
I created a new class called StateManager, which is responsible to cache the last searched events, so we don't need to call the API again, when the filters don't change.