### PR TITLE
Order imports alphabetically

### DIFF
--- a/populate_country_table.py
+++ b/populate_country_table.py
@@ -1,7 +1,8 @@
 
-import os
 import django
 import requests
+import os
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'search_events.settings.dev')
 django.setup()
 

--- a/search_events_app/services/filter_manager.py
+++ b/search_events_app/services/filter_manager.py
@@ -1,6 +1,6 @@
 from search_events_app.services.filters.country_filter import CountryFilter
-from search_events_app.services.filters.online_filter import OnlineFilter
 from search_events_app.services.filters.language_filter import LanguageFilter
+from search_events_app.services.filters.online_filter import OnlineFilter
 
 
 class FilterManager:

--- a/search_events_app/services/filters/country_filter.py
+++ b/search_events_app/services/filters/country_filter.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 
-from search_events_app.services.filters.filter import Filter
 from search_events_app.models.country import Country
+from search_events_app.services.filters.filter import Filter
 
 
 class CountryFilter(Filter):

--- a/search_events_app/services/filters/language_filter.py
+++ b/search_events_app/services/filters/language_filter.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 
-from search_events_app.services.filters.filter import Filter
 from search_events_app.models.language import Language
+from search_events_app.services.filters.filter import Filter
 
 
 class LanguageFilter(Filter):

--- a/search_events_app/tests/models/test_event.py
+++ b/search_events_app/tests/models/test_event.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
-from search_events_app.models.event import Event
 from search_events_app.models.country import Country
+from search_events_app.models.event import Event
 from search_events_app.models.feature import Feature
 
 

--- a/search_events_app/tests/services/test_api_response_processor.py
+++ b/search_events_app/tests/services/test_api_response_processor.py
@@ -1,11 +1,11 @@
 from django.test import TestCase
 
+from search_events_app.models.country import Country
 from search_events_app.services.api_response_processor import (
-    process_events,
     get_country,
     get_tag,
+    process_events,
 )
-from search_events_app.models.country import Country
 
 
 class TestApiResponseProcessor(TestCase):

--- a/search_events_app/tests/services/test_api_service.py
+++ b/search_events_app/tests/services/test_api_service.py
@@ -1,6 +1,6 @@
 from unittest.mock import (
-    patch,
     MagicMock,
+    patch,
 )
 
 from django.test import TestCase

--- a/search_events_app/tests/services/test_filter.py
+++ b/search_events_app/tests/services/test_filter.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
-from search_events_app.services.filters.country_filter import CountryFilter
 from search_events_app.models.country import Country
+from search_events_app.services.filters.country_filter import CountryFilter
 
 
 class TestFilters(TestCase):

--- a/search_events_app/tests/services/test_filter_manager.py
+++ b/search_events_app/tests/services/test_filter_manager.py
@@ -1,4 +1,7 @@
-from unittest.mock import (MagicMock, patch)
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
 from django.test import TestCase
 

--- a/search_events_app/tests/services/test_language_filter.py
+++ b/search_events_app/tests/services/test_language_filter.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
-from search_events_app.services.filters.language_filter import LanguageFilter
 from search_events_app.models.language import Language
+from search_events_app.services.filters.language_filter import LanguageFilter
 
 
 class TestLanguageFilter(TestCase):

--- a/search_events_app/tests/services/test_online_filter.py
+++ b/search_events_app/tests/services/test_online_filter.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
-from search_events_app.services.filters.online_filter import OnlineFilter
 from search_events_app.models.online_parameters import OnlineParameters
+from search_events_app.services.filters.online_filter import OnlineFilter
 
 
 class TestFilters(TestCase):

--- a/search_events_app/tests/services/test_post_request_processor.py
+++ b/search_events_app/tests/services/test_post_request_processor.py
@@ -1,9 +1,9 @@
 from django.test import TestCase
 
 from search_events_app.models.event import Event
+from search_events_app.services.post_request_processor import validate_filters
 from search_events_app.views import DTOFilter
 
-from search_events_app.services.post_request_processor import validate_filters
 
 class TestPostRequestProcessor(TestCase):
     def setUp(self):

--- a/search_events_app/tests/views/test_views.py
+++ b/search_events_app/tests/views/test_views.py
@@ -1,14 +1,14 @@
 from unittest.mock import (
 	MagicMock,
-	patch
+	patch,
 )
-from django.test import Client
 
+from django.test import Client
 from django.test import TestCase
 
 from search_events_app.models.country import Country
-from search_events_app.models.language import Language
 from search_events_app.models.event import Event
+from search_events_app.models.language import Language
 from search_events_app.services.api_service import ApiService
 from search_events_app.services.filter_manager import FilterManager
 from search_events_app.services.state_manager import StateManager


### PR DESCRIPTION
I ordered the imports alphabetically, first by module and then by class:

The pattern I followed is:

- python imports

- django imports

- our app imports