### PR TITLE
replace url country name in filter

### DIFF
--- a/static/js/filter_country.js
+++ b/static/js/filter_country.js
@@ -150,14 +150,13 @@ function toggleDisable(domId, value) {
 }
 
 function querySt(ji) {
-
     hu = window.location.search.substring(1);
     gy = hu.split("&");
 
     for (i=0;i<gy.length;i++) {
         ft = gy[i].split("=");
         if (ft[0] == ji) {
-            return ft[1].replace("+"," ");
+            return ft[1].replace(/\+/g, " ");
         }
     }
 }


### PR DESCRIPTION
I replaced the + sign by a space in the country name of the url, so we show the actual name of the country in the submitted filter