### PR TITLE
Show 'None' if the event hasn't organizer

### DIFF
--- a/search_events_app/services/db/db_response_processor.py
+++ b/search_events_app/services/db/db_response_processor.py
@@ -38,9 +38,9 @@ def get_url(item):
 
 
 def get_organizer(item):
-    if item[4]:
+    if item[4] and item[4].strip():
         return item[4]
-    if item[5]:
+    if item[5] and item[5].strip():
         return item[5]
     return None
 

--- a/tests/services/db/test_db_response_processor.py
+++ b/tests/services/db/test_db_response_processor.py
@@ -141,8 +141,8 @@ class TestDBResponseProcessor(TestCase):
 			'LEARN WHAT IT TAKES TO BUY A HOME IN LAS VEGAS (FREE WINE &amp; PIZZA)',
 			'Business & Professional',
 			'Meeting or Networking Event',
-			None,
-			None,
+			' ',
+			' ',
 			'ZX',
 			'2020-12-16',
 			'en_US'


### PR DESCRIPTION
We show 'None' in the organizer name column if the event hasn't organizer