### PR TITLE
Add Facebook Link in FE

### DIFF
--- a/search_events_app/dto/dto_db_service_filter.py
+++ b/search_events_app/dto/dto_db_service_filter.py
@@ -1,5 +1,7 @@
 class DTODBServiceFilter:
 
     def __init__(self, **kwargs):
-        self.join_query = kwargs.get('join_query', '')
+        self.select_query = kwargs.get('select_query', '')
         self.where_query = kwargs.get('where_query', '')
+        self.join_query = kwargs.get('join_query', '')
+        self.group_query = kwargs.get('group_query', '')

--- a/search_events_app/filters/feature_filter_manager.py
+++ b/search_events_app/filters/feature_filter_manager.py
@@ -35,6 +35,12 @@ class FeatureFilterManager(Filter):
             latest_filter.apply_filter(features_codes)
         self.has_changed = len([latest_filter for latest_filter in self.value if latest_filter.has_changed]) > 0
 
+    def get_select_query(self):
+        select_query = ''
+        for feature in self.value:
+            select_query += feature.get_select_query()
+        return select_query
+
     def get_join_query(self):
         join_query = []
         for feature in self.value:
@@ -48,3 +54,9 @@ class FeatureFilterManager(Filter):
         for feature in self.value:
             where_query += feature.get_where_query()
         return where_query
+
+    def get_group_query(self):
+        group_query = ''
+        for feature in self.value:
+            group_query += feature.get_group_query()
+        return group_query

--- a/search_events_app/filters/features/facebook_filter.py
+++ b/search_events_app/filters/features/facebook_filter.py
@@ -9,6 +9,11 @@ class FacebookFilter(Filter):
         if self.has_changed:
             self.value = new_filter
 
+    def get_select_query(self):
+        if self.value:
+            return ', fb.facebook_event_id'
+        return ''
+
     def get_join_query(self):
         if self.value:
             return [
@@ -19,6 +24,10 @@ class FacebookFilter(Filter):
             ]
         return ['']
 
-
     def get_where_query(self):
+        return ''
+
+    def get_group_query(self):
+        if self.value:
+            return ', fb.facebook_event_id'
         return ''

--- a/search_events_app/filters/filter.py
+++ b/search_events_app/filters/filter.py
@@ -10,7 +10,10 @@ class Filter:
     @abstractmethod
     def apply_filter(self, request):
         pass
-    
+
+    def get_select_query(self):
+        return ''
+
     @abstractmethod
     def get_join_query(self):
         pass
@@ -18,3 +21,6 @@ class Filter:
     @abstractmethod
     def get_where_query(self):
         pass
+
+    def get_group_query(self):
+        return ''

--- a/search_events_app/models/event.py
+++ b/search_events_app/models/event.py
@@ -14,6 +14,7 @@ class Event:
             admin_url=None,
             eb_studio_url=None,
             status=None,
+            facebook=None,
             **kwargs
     ):
         self.name = name
@@ -27,6 +28,7 @@ class Event:
         self.admin_url = admin_url
         self.eb_studio_url = eb_studio_url
         self.status = status
+        self.facebook = facebook
         if not feature:
             self.feature = []
         else:

--- a/search_events_app/services/db/db_response_processor.py
+++ b/search_events_app/services/db/db_response_processor.py
@@ -20,6 +20,7 @@ def process_events(data):
                 'admin_url': get_admin_url(item),
                 'eb_studio_url': get_eb_studio_url(item),
                 'status': get_status(item),
+                'facebook': get_facebook(item)
             }
             events.append(event_dict)
     return events
@@ -65,6 +66,13 @@ def get_status(item):
         if item[9]:
             return item[9]
         return None
+    except Exception:
+        return None
+
+
+def get_facebook(item):
+    try:
+        return f'https://wwww.facebook.com/events/{item[10]}'
     except Exception:
         return None
 

--- a/search_events_app/services/db/db_service.py
+++ b/search_events_app/services/db/db_service.py
@@ -31,9 +31,11 @@ class DBService:
         order_by_base_query = query_parameters.order_by
         limit = query_parameters.limit
         for dto in dto_filters_array:
+            select_base_query += " "+dto.select_query
             for dto_join in dto.join_query:
                 join_base_query += " "+dto_join
             where_base_query += " "+dto.where_query
+            group_by_base_query += " "+dto.group_query
         query = select_base_query+join_base_query+where_base_query+group_by_base_query+order_by_base_query+limit
         return query
 

--- a/search_events_app/services/filter_manager.py
+++ b/search_events_app/services/filter_manager.py
@@ -54,8 +54,11 @@ class FilterManager:
         list_dto = []
         dict_dto = {}
         for filter_ in cls.latest_filters:
+            dict_dto['select_query'] = filter_.get_select_query()
             dict_dto['join_query'] = filter_.get_join_query()
             dict_dto['where_query'] = filter_.get_where_query()
+            dict_dto['group_query'] = filter_.get_group_query()
+
             list_dto.append(DTODBServiceFilter(**dict_dto))
 
         return list_dto

--- a/search_events_app/views/event_list_view.py
+++ b/search_events_app/views/event_list_view.py
@@ -27,6 +27,7 @@ from search_events_app.models import (
 class EventListView(ListView):
 
     has_eb_studio = False
+    has_facebook = False
 
     def get(self, request):
         self.template_name = TemplateFactory.get_template(request)
@@ -50,10 +51,12 @@ class EventListView(ListView):
             events = DBService.get_events(db_service_filters, query_parameters, self.request.session)
             StateManager.set_events(events)
             self.has_eb_studio = len([event for event in events if event.eb_studio_url]) > 0
+            self.has_facebook = len([event for event in events if event.facebook]) > 0
             StateManager.change_url(self.request)
             return events
         events = StateManager.get_last_searched_events()
         self.has_eb_studio = len([event for event in events if event.eb_studio_url]) > 0
+        self.has_facebook = len([event for event in events if event.facebook]) > 0
         return events
 
     def get_context_data(self, **kwargs):
@@ -65,7 +68,7 @@ class EventListView(ListView):
             context.update(class_.get_context())
 
         context['username'] = self.request.session['username']
-        context['has_eb_studio'] = self.has_eb_studio
+        context['has_links'] = self.has_eb_studio or self.has_facebook
         context['specific_event'] = 'SpecificEvent' in self.request.path
 
         return context

--- a/templates/table_events.html
+++ b/templates/table_events.html
@@ -11,19 +11,19 @@
         <thead class="thead-blue-eb text-white">
             <tr>
                 <th>Admin Dashboard</th>
-                {% if has_eb_studio and not specific_event %}
-                    <th class="text-center">EB Studio Page</th>
-                {% endif %}
                 <th class="text-center">Name</th>
                 <th>Category</th>
                 <th>Format</th>
                 <th>Organizer</th>
                 <th>Country</th>
-                <th>Start date</th>
+                <th>Start Date</th>
                 <th>Language</th>
                 {% if specific_event %}
                 <th class="text-center">Status</th>
                 {% endif %}
+                {% if has_links and not specific_event %}
+                <th class="text-center">External Links</th>
+            {% endif %}
 
             </tr>
         </thead>
@@ -37,17 +37,6 @@
                                 <i class="material-icons">link</i>
                             </a>
                         </td>
-                        {% if has_eb_studio and not specific_event %}
-                            <td class="text-center">
-                                {% if event.eb_studio_url  %}
-                                    <a class="text-orange" href="{{event.eb_studio_url}}" target="_blank">
-                                        <i class="material-icons">link</i>
-                                    </a>
-                                {% else %}
-                                    <i>None</i>
-                                {% endif %}
-                            </td>
-                        {% endif %}
                         <td style="word-wrap: break-word; max-width: 300px;">
                             <a class="text-orange" href="{{ event.url }}" target="_blank">
                                 {{ event.name|safe }}
@@ -61,6 +50,24 @@
                         <td>{{ event.language }}</td>
                         {% if specific_event %}
                             <td>{{event.status}}</td>
+                        {% endif %}
+                        {% if has_links and not specific_event %}
+                            <td class="text-center">
+                                {% if event.eb_studio_url or event.facebook %}
+                                    {% if event.eb_studio_url  %}
+                                        <a class="text-orange" href="{{event.eb_studio_url}}" target="_blank">
+                                            <i class="material-icons">link</i>
+                                        </a>
+                                    {% endif %}
+                                    {% if event.facebook  %}
+                                        <a class="text-blue" href="{{event.facebook}}" target="_blank">
+                                            <i class="material-icons">facebook</i>
+                                        </a>
+                                    {% endif %}
+                                {% else %}
+                                    <i>None</i>
+                                {% endif %}
+                            </td>
                         {% endif %}
                     </tr>
                 {% endfor %}

--- a/tests/services/db/test_db_response_processor.py
+++ b/tests/services/db/test_db_response_processor.py
@@ -51,6 +51,7 @@ class TestDBResponseProcessor(TestCase):
 			'admin_url': 'https://www.eventbrite.com/myevent?eid=99894936444',
 			'eb_studio_url': None,
 			'status': None,
+			'facebook': None,
 		}
 
 		self.assertIsInstance(result[0], dict)

--- a/tests/services/db/test_db_service.py
+++ b/tests/services/db/test_db_service.py
@@ -138,21 +138,23 @@ class TestDbService(TestCase):
 
     def test_format_query_with_filters(self):
         where_query = FindFeatureQueryParameters.constraints + " " + "AND dw_event.event_language LIKE '%en%'"
-        expected = FindFeatureQueryParameters.columns_select + FindFeatureQueryParameters.default_tables + where_query + FindFeatureQueryParameters.group_by
+        expected = FindFeatureQueryParameters.columns_select + FindFeatureQueryParameters.default_tables + where_query + " " + FindFeatureQueryParameters.group_by
         expected += FindFeatureQueryParameters.order_by + FindFeatureQueryParameters.limit
 
         result = DBService.format_query(self.mock_dto_filter, FindFeatureQueryParameters)
-        self.assertEqual(result, expected)
+
+        self.assertEqual(result.split(), expected.split())
 
     def test_format_join_query_with_filters(self):
         mock_dto_filter = [DTODBServiceFilter(join_query=['INNER JOIN dw.f_ticket_merchandise_purchase f ON f.event_id = dw_event.event_id'], where_query='')]
         join_query = FindFeatureQueryParameters.default_tables + " " +  "INNER JOIN dw.f_ticket_merchandise_purchase f ON f.event_id = dw_event.event_id"
         where_query = FindFeatureQueryParameters.constraints + " "
-        expected = FindFeatureQueryParameters.columns_select + join_query + where_query + FindFeatureQueryParameters.group_by
+        expected = " " + FindFeatureQueryParameters.columns_select + join_query + where_query + " " + FindFeatureQueryParameters.group_by
         expected += FindFeatureQueryParameters.order_by + FindFeatureQueryParameters.limit
 
         result = DBService.format_query(mock_dto_filter, FindFeatureQueryParameters)
-        self.assertEqual(result, expected)
+
+        self.assertEqual(result.split(), expected.split())
 
     @patch.object(ConnectionManager, 'connect')
     @patch.object(DBService, 'execute_query')


### PR DESCRIPTION
Add facebook link in fe.
![image](https://user-images.githubusercontent.com/62262333/89445311-5a7d1800-d729-11ea-8a1b-9838954b1cca.png)
Until now, we used to retrieve the eb_studio and facebook fields in the default query (select and group by), no matters if we actually wanted to get them or not. Now, we changed this behaviour so it allows you to add new values to the default ones.